### PR TITLE
Fixed issue with ClassReflection.vars method

### DIFF
--- a/src/reflection.py
+++ b/src/reflection.py
@@ -113,6 +113,7 @@ class ClassReflection(Reflection):
             if isinstance(node, ast.Attribute) and
             not isinstance(node.value, ast.Call) and
             not isinstance(node.value, ast.Attribute) and
+            not isinstance(node.value, ast.Str) and
             node.value.id == 'self'
         }
 

--- a/src/reflection.py
+++ b/src/reflection.py
@@ -94,8 +94,8 @@ class ClassReflection(Reflection):
 
     def vars(self):
         result = self.__class_vars()
-        result |= self.__instance_vars()
-        result -= {node.name for node in self.__class_methods()}
+        result |= (self.__instance_vars() -
+                   {node.name for node in self.__class_methods()})
         return list(result)
 
     def __class_vars(self):
@@ -110,7 +110,10 @@ class ClassReflection(Reflection):
         return {
             node.attr
             for node in ast.walk(self.__node)
-            if isinstance(node, ast.Attribute) and node.value.id == 'self'
+            if isinstance(node, ast.Attribute) and
+            not isinstance(node.value, ast.Call) and
+            not isinstance(node.value, ast.Attribute) and
+            node.value.id == 'self'
         }
 
     def __class_methods(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27, py35, py35, py36
+envlist=py27, py34, py35, py36
 
 [testenv]
 deps=


### PR DESCRIPTION
Steps to reproduce bug:
* Load the 'reflection.py' file using ModuleReflection.from_file method
* Find the class 'ModuleReflection'
* Call the method vars of the ClassReflection object

The following error should appear:

AttributeError: 'Call' object has no attribute 'id'

This bug is fixed by excluding ast.Call and ast.Attribute in the
ClassReflection.vars method